### PR TITLE
Improve MCP tool registry discovery

### DIFF
--- a/agent.tools.yaml
+++ b/agent.tools.yaml
@@ -1,0 +1,498 @@
+tools:
+  - name: semgrep
+    display_name: Semgrep SAST
+    type: security
+    description: Escáner SAST rápido para múltiples lenguajes y frameworks.
+    enabled: true
+    priority: 10
+    tasks: [security, analysis]
+    languages: [csharp, python, javascript, typescript, java, go]
+    file_extensions: [cs, py, js, ts, java, go]
+    intent_keywords: [semgrep, vulnerabilidad, security, sast, escaneo, audit]
+    execution:
+      mode: cli
+      command: semgrep
+      arguments:
+        - "--config"
+        - "auto"
+        - "--json"
+        - "{target}"
+    metadata:
+      result_format: json
+  - name: gitleaks
+    display_name: Gitleaks Secret Scanner
+    type: security
+    description: Detecta secretos y credenciales comprometidas en repositorios Git.
+    enabled: true
+    priority: 20
+    tasks: [secret-scanning, security]
+    languages: []
+    file_extensions: []
+    intent_keywords: [gitleaks, secretos, credenciales, secret, leak]
+    execution:
+      mode: cli
+      command: gitleaks
+      arguments:
+        - "detect"
+        - "--no-banner"
+        - "--redact"
+        - "--report-format"
+        - "json"
+        - "--source"
+        - "{target}"
+    metadata:
+      result_format: json
+  - name: trivy_fs
+    display_name: Trivy Filesystem Scan
+    type: security
+    description: Análisis de vulnerabilidades y dependencias con Trivy sobre el sistema de archivos.
+    enabled: true
+    priority: 30
+    tasks: [security, dependency]
+    languages: []
+    file_extensions: []
+    intent_keywords: [trivy, scan, dependencias, vulnerabilidad, sast]
+    execution:
+      mode: cli
+      command: trivy
+      arguments:
+        - "fs"
+        - "--severity"
+        - "HIGH,CRITICAL"
+        - "--format"
+        - "json"
+        - "{target}"
+    metadata:
+      result_format: json
+  - name: dotnet_format
+    display_name: dotnet-format
+    type: lint
+    description: Alinea el estilo de código y corrige problemas de formato en soluciones .NET.
+    enabled: true
+    priority: 5
+    tasks: [lint, formatting]
+    languages: [csharp]
+    file_extensions: [cs, csproj, sln]
+    intent_keywords: [format, formatea, lint, estilo, dotnet-format]
+    execution:
+      mode: cli
+      command: dotnet
+      arguments:
+        - "format"
+        - "{target}"
+    metadata:
+      result_format: text
+  - name: dotnet_test
+    display_name: dotnet test runner
+    type: testing
+    description: Ejecuta la suite de pruebas de un proyecto o solución .NET.
+    enabled: true
+    priority: 15
+    tasks: [testing]
+    languages: [csharp]
+    file_extensions: [csproj, sln]
+    intent_keywords: [test, pruebas, cobertura, dotnet test]
+    execution:
+      mode: cli
+      command: dotnet
+      arguments:
+        - "test"
+        - "{target}"
+    metadata:
+      result_format: text
+  - name: docfx_metadata
+    display_name: DocFX Metadata
+    type: documentation
+    description: Genera metadatos de documentación para proyectos .NET con DocFX.
+    enabled: true
+    priority: 40
+    tasks: [documentation]
+    languages: [csharp]
+    file_extensions: [json, csproj, sln]
+    intent_keywords: [docfx, documentación, docs]
+    execution:
+      mode: cli
+      command: docfx
+      arguments:
+        - "metadata"
+        - "{target}"
+    metadata:
+      result_format: text
+  - name: dotnet_list_packages
+    display_name: dotnet list package --outdated
+    type: dependency
+    description: Identifica paquetes NuGet desactualizados dentro de un proyecto o solución.
+    enabled: true
+    priority: 25
+    tasks: [dependency]
+    languages: [csharp]
+    file_extensions: [csproj, sln]
+    intent_keywords: [dependencias, outdated, paquetes, actualiza]
+    execution:
+      mode: cli
+      command: dotnet
+      arguments:
+        - "list"
+        - "{target}"
+        - "package"
+        - "--outdated"
+    metadata:
+      result_format: text
+  - name: yq_cli
+    display_name: yq YAML/JSON processor
+    type: conversion
+    description: Convierte archivos YAML y JSON utilizando la utilidad yq.
+    enabled: true
+    priority: 35
+    tasks: [conversion]
+    languages: []
+    file_extensions: [yml, yaml, json]
+    intent_keywords: [yq, convierte, conversion, json, yaml]
+    execution:
+      mode: cli
+      command: yq
+      arguments:
+        - "eval"
+        - "-o=json"
+        - "."
+        - "{target}"
+    metadata:
+      result_format: json
+  - name: yaml_json_builtin
+    display_name: Conversor YAML ↔ JSON
+    type: conversion
+    description: Conversión integrada entre YAML y JSON sin depender de herramientas externas.
+    enabled: true
+    priority: 1
+    tasks: [conversion]
+    languages: []
+    file_extensions: [yaml, yml, json]
+    intent_keywords: [convertir, yaml, json, transforma, formato]
+    forward_result_to_agent: false
+    execution:
+      mode: builtin
+      handler: yaml-json
+    metadata:
+      direction: yaml-to-json
+  - name: json_yaml_builtin
+    display_name: Conversor JSON → YAML
+    type: conversion
+    description: Conversión integrada de JSON hacia YAML utilizando el motor interno.
+    enabled: true
+    priority: 2
+    tasks: [conversion]
+    languages: []
+    file_extensions: [json, yaml, yml]
+    intent_keywords: [convertir, yaml, json, transforma, formato]
+    forward_result_to_agent: false
+    execution:
+      mode: builtin
+      handler: yaml-json
+    metadata:
+      direction: json-to-yaml
+  - name: eslint
+    display_name: ESLint
+    type: lint
+    description: Analizador estático y linter para proyectos JavaScript y TypeScript.
+    enabled: true
+    priority: 12
+    tasks: [lint, analysis]
+    languages: [javascript, typescript]
+    file_extensions: [js, jsx, ts, tsx]
+    intent_keywords: [eslint, lint, estilo, javascript, typescript]
+    execution:
+      mode: cli
+      command: npx
+      arguments:
+        - eslint
+        - "{target}"
+        - "--format"
+        - json
+    metadata:
+      result_format: json
+  - name: prettier
+    display_name: Prettier Formatter
+    type: formatting
+    description: Formateador de código para proyectos JavaScript, TypeScript y frontend.
+    enabled: true
+    priority: 18
+    tasks: [formatting]
+    languages: [javascript, typescript, css, json, markdown]
+    file_extensions: [js, jsx, ts, tsx, css, scss, json, md]
+    intent_keywords: [prettier, formatea, format, frontend]
+    execution:
+      mode: cli
+      command: npx
+      arguments:
+        - prettier
+        - "{target}"
+        - "--write"
+    metadata:
+      result_format: text
+  - name: flake8
+    display_name: Flake8 Linter
+    type: lint
+    description: Linter para código Python que combina PyFlakes, pycodestyle y McCabe.
+    enabled: true
+    priority: 14
+    tasks: [lint, analysis]
+    languages: [python]
+    file_extensions: [py]
+    intent_keywords: [flake8, lint, pep8, estilo, python]
+    execution:
+      mode: cli
+      command: flake8
+      arguments:
+        - "{target}"
+        - "--format=json"
+    metadata:
+      result_format: json
+  - name: black
+    display_name: Black Formatter
+    type: formatting
+    description: Formateador opinado para proyectos Python.
+    enabled: true
+    priority: 22
+    tasks: [formatting]
+    languages: [python]
+    file_extensions: [py]
+    intent_keywords: [black, formatea, format, python]
+    execution:
+      mode: cli
+      command: black
+      arguments:
+        - "{target}"
+        - "--quiet"
+    metadata:
+      result_format: text
+  - name: bandit
+    display_name: Bandit Security Scanner
+    type: security
+    description: Analiza código Python para detectar vulnerabilidades comunes.
+    enabled: true
+    priority: 28
+    tasks: [security, analysis]
+    languages: [python]
+    file_extensions: [py]
+    intent_keywords: [bandit, security, vulnerabilidad, python]
+    execution:
+      mode: cli
+      command: bandit
+      arguments:
+        - "-r"
+        - "{target}"
+        - "-f"
+        - json
+    metadata:
+      result_format: json
+  - name: pip_audit
+    display_name: pip-audit Dependency Scanner
+    type: dependency
+    description: Detecta vulnerabilidades en dependencias Python utilizando el ecosistema PyPI.
+    enabled: true
+    priority: 32
+    tasks: [dependency, security]
+    languages: [python]
+    file_extensions: [pyproject.toml, requirements.txt]
+    intent_keywords: [pip-audit, dependencias, seguridad, python]
+    execution:
+      mode: cli
+      command: pip-audit
+      arguments:
+        - "--progress-spinner"
+        - "off"
+        - "--format"
+        - json
+        - "--requirement"
+        - "{target}"
+    metadata:
+      result_format: json
+  - name: npm_audit
+    display_name: npm audit
+    type: dependency
+    description: Auditoría de dependencias npm para detectar vulnerabilidades conocidas.
+    enabled: true
+    priority: 34
+    tasks: [dependency, security]
+    languages: [javascript, typescript]
+    file_extensions: [json]
+    intent_keywords: [npm audit, dependencias, seguridad, javascript]
+    execution:
+      mode: cli
+      command: npm
+      arguments:
+        - audit
+        - "--json"
+        - "--prefix"
+        - "{target}"
+    metadata:
+      result_format: json
+  - name: ktlint
+    display_name: ktlint
+    type: lint
+    description: Linter para proyectos Kotlin compatible con Gradle y Maven.
+    enabled: true
+    priority: 16
+    tasks: [lint, formatting]
+    languages: [kotlin]
+    file_extensions: [kt, kts]
+    intent_keywords: [ktlint, kotlin, lint, format]
+    execution:
+      mode: cli
+      command: ktlint
+      arguments:
+        - "{target}"
+        - "--reporter=json"
+    metadata:
+      result_format: json
+  - name: gradle_test
+    display_name: Gradle Test Runner
+    type: testing
+    description: Ejecuta pruebas automatizadas en proyectos JVM mediante Gradle.
+    enabled: true
+    priority: 26
+    tasks: [testing]
+    languages: [kotlin, java]
+    file_extensions: [gradle, kts]
+    intent_keywords: [gradle, test, junit, ejecutar pruebas]
+    execution:
+      mode: cli
+      command: ./gradlew
+      arguments:
+        - test
+    metadata:
+      result_format: text
+  - name: pytest
+    display_name: pytest
+    type: testing
+    description: Ejecuta pruebas unitarias Python con Pytest.
+    enabled: true
+    priority: 24
+    tasks: [testing]
+    languages: [python]
+    file_extensions: [py]
+    intent_keywords: [pytest, test, pruebas, python]
+    execution:
+      mode: cli
+      command: pytest
+      arguments:
+        - "{target}"
+        - "-q"
+        - "--maxfail=1"
+        - "--disable-warnings"
+        - "--json-report"
+    metadata:
+      result_format: json
+  - name: markdownlint
+    display_name: Markdownlint CLI
+    type: lint
+    description: Analiza archivos Markdown para garantizar consistencia y buenas prácticas.
+    enabled: true
+    priority: 36
+    tasks: [lint]
+    languages: [markdown]
+    file_extensions: [md, markdown]
+    intent_keywords: [markdownlint, lint, markdown]
+    execution:
+      mode: cli
+      command: npx
+      arguments:
+        - markdownlint-cli2
+        - "{target}"
+        - "--output-format"
+        - json
+    metadata:
+      result_format: json
+  - name: yamllint
+    display_name: yamllint
+    type: lint
+    description: Validador y linter para archivos YAML con soporte para esquemas.
+    enabled: true
+    priority: 38
+    tasks: [lint, validation]
+    languages: [yaml]
+    file_extensions: [yaml, yml]
+    intent_keywords: [yamllint, lint, yaml, validar]
+    execution:
+      mode: cli
+      command: yamllint
+      arguments:
+        - "-f"
+        - parsable
+        - "{target}"
+    metadata:
+      result_format: text
+  - name: shellcheck
+    display_name: ShellCheck
+    type: lint
+    description: Linter para scripts shell que detecta errores y malas prácticas.
+    enabled: true
+    priority: 42
+    tasks: [lint, analysis]
+    languages: [shell]
+    file_extensions: [sh, bash]
+    intent_keywords: [shellcheck, bash, shell, lint]
+    execution:
+      mode: cli
+      command: shellcheck
+      arguments:
+        - "{target}"
+        - "--format"
+        - json
+    metadata:
+      result_format: json
+  - name: hadolint
+    display_name: Hadolint
+    type: lint
+    description: Analiza Dockerfiles para detectar problemas de seguridad y estilo.
+    enabled: true
+    priority: 44
+    tasks: [lint, security]
+    languages: [docker]
+    file_extensions: [Dockerfile]
+    intent_keywords: [hadolint, docker, lint, seguridad]
+    execution:
+      mode: cli
+      command: hadolint
+      arguments:
+        - "{target}"
+        - "-f"
+        - json
+    metadata:
+      result_format: json
+  - name: terraform_fmt
+    display_name: Terraform fmt
+    type: formatting
+    description: Normaliza el formato de archivos Terraform.
+    enabled: true
+    priority: 46
+    tasks: [formatting]
+    languages: [hcl]
+    file_extensions: [tf]
+    intent_keywords: [terraform, fmt, formatea, infraestructura]
+    execution:
+      mode: cli
+      command: terraform
+      arguments:
+        - fmt
+        - "{target}"
+    metadata:
+      result_format: text
+  - name: terraform_validate
+    display_name: Terraform validate
+    type: validation
+    description: Valida configuraciones Terraform asegurando integridad sintáctica.
+    enabled: true
+    priority: 48
+    tasks: [validation]
+    languages: [hcl]
+    file_extensions: [tf]
+    intent_keywords: [terraform, validate, validar, infraestructura]
+    execution:
+      mode: cli
+      command: terraform
+      arguments:
+        - validate
+        - "{target}"
+    metadata:
+      result_format: text

--- a/appsettings.json
+++ b/appsettings.json
@@ -17,5 +17,11 @@
       "allow_file_writes": true,
       "working_directory": "."
     }
+  },
+  "Tools": {
+    "configuration": "agent.tools.yaml",
+    "auto_execute": true,
+    "prefer_local": true,
+    "max_output_chars": 6000
   }
 }

--- a/src/Application/Configurations/ToolingConfiguration.cs
+++ b/src/Application/Configurations/ToolingConfiguration.cs
@@ -1,0 +1,33 @@
+using System.Text.Json.Serialization;
+
+namespace RapidCli.Application.Configurations;
+
+/// <summary>
+/// Represents configuration options that control how MCP tools are loaded and orchestrated.
+/// </summary>
+public sealed class ToolingConfiguration
+{
+    /// <summary>
+    /// Gets or sets the relative or absolute path to the tool registry file.
+    /// </summary>
+    [JsonPropertyName("configuration")]
+    public string ConfigurationPath { get; set; } = "agent.tools.yaml";
+
+    /// <summary>
+    /// Gets or sets a value indicating whether tools should be executed automáticamente when a match is found.
+    /// </summary>
+    [JsonPropertyName("auto_execute")]
+    public bool AutoExecute { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether availability checks should prefer local installations when possible.
+    /// </summary>
+    [JsonPropertyName("prefer_local")]
+    public bool PreferLocalInstallations { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the maximum number of characters stored from a tool output.
+    /// </summary>
+    [JsonPropertyName("max_output_chars")]
+    public int MaxOutputCharacters { get; set; } = 8000;
+}

--- a/src/Application/RapidCli.Application.csproj
+++ b/src/Application/RapidCli.Application.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.9" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.9" />
+    <PackageReference Include="YamlDotNet" Version="15.3.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Application/Services/DependencyInjection.cs
+++ b/src/Application/Services/DependencyInjection.cs
@@ -2,6 +2,9 @@ using Microsoft.Extensions.DependencyInjection;
 using RapidCli.Application.Agents;
 using RapidCli.Application.Conversation;
 using RapidCli.Application.Sessions;
+using RapidCli.Application.Tools;
+using RapidCli.Application.Tools.Providers;
+using RapidCli.Domain.Interfaces;
 
 namespace RapidCli.Application.Services;
 
@@ -22,6 +25,11 @@ public static class DependencyInjection
         services.AddSingleton<ConfigurationService>();
         services.AddSingleton<ChatService>();
         services.AddSingleton<AgentService>();
+        services.AddSingleton<McpIntentClassifier>();
+        services.AddSingleton<McpToolRegistry>();
+        services.AddSingleton<ToolOrchestrator>();
+        services.AddSingleton<IAgentToolProvider, CliToolProvider>();
+        services.AddSingleton<IAgentToolProvider, YamlJsonToolProvider>();
         return services;
     }
 }

--- a/src/Application/Tools/McpIntentClassifier.cs
+++ b/src/Application/Tools/McpIntentClassifier.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace RapidCli.Application.Tools;
+
+/// <summary>
+/// Performs lightweight semantic analysis on top of the user input to decide which MCP tool is relevant.
+/// </summary>
+public sealed class McpIntentClassifier
+{
+    private static readonly Regex FilePattern = new(@"(?<path>[^\s]+\.(cs|fs|vb|py|rb|js|ts|tsx|jsx|java|kt|kts|go|rs|php|json|ya?ml|md|xml|gradle|sln|csproj))", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex LanguagePattern = new(@"\b(c#|csharp|dotnet|f#|javascript|typescript|python|java|kotlin|go|rust|php|ruby|kotlin)\b", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private static readonly (string Task, string[] Keywords)[] TaskMappings =
+    [
+        ("security", new[] { "security", "seguridad", "vulnerability", "vulnerabilidad", "sast", "semgrep", "owasp", "auditar" }),
+        ("secret-scanning", new[] { "secret", "secreto", "credencial", "gitleaks", "api key" }),
+        ("lint", new[] { "lint", "linter", "formatea", "format", "dotnet-format", "style", "analizador" }),
+        ("testing", new[] { "test", "tests", "pruebas", "coverage", "unitarias" }),
+        ("documentation", new[] { "docfx", "documenta", "documentación", "dokka", "docs" }),
+        ("dependency", new[] { "dependencia", "dependencies", "árbol", "tree", "sbom" }),
+        ("analysis", new[] { "análisis", "analysis", "analiza", "static" }),
+        ("conversion", new[] { "convierte", "convert", "transforma", "traduce", "yq", "yaml", "json", "xml" }),
+        ("logs", new[] { "log", "logs", "registro", "traza" }),
+    ];
+
+    /// <summary>
+    /// Creates an <see cref="McpToolRequest"/> using keywords and heuristics.
+    /// </summary>
+    /// <param name="objective">The user objective.</param>
+    public McpToolRequest Classify(string objective)
+    {
+        if (string.IsNullOrWhiteSpace(objective))
+        {
+            throw new ArgumentException("Objective cannot be empty.", nameof(objective));
+        }
+
+        var lowered = objective.ToLowerInvariant();
+        var keywords = ExtractKeywords(lowered);
+        var task = DetermineTask(keywords, lowered);
+        var targetPath = ExtractPath(objective);
+        var language = ExtractLanguage(lowered, targetPath);
+        var extension = ExtractExtension(targetPath);
+        var parameters = BuildParameters(targetPath, extension, language);
+
+        return new McpToolRequest(objective, task, language, extension, targetPath, keywords, parameters);
+    }
+
+    private static IReadOnlyCollection<string> ExtractKeywords(string normalized)
+    {
+        var delimiters = new[] { ' ', '\n', '\r', '\t', '.', ',', ';', ':', '!', '?', '"', '\'', '(', ')', '[', ']' };
+        var words = normalized.Split(delimiters, StringSplitOptions.RemoveEmptyEntries);
+        return new HashSet<string>(words, StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static string? DetermineTask(IEnumerable<string> keywords, string normalized)
+    {
+        foreach (var (task, signals) in TaskMappings)
+        {
+            if (signals.Any(signal => keywords.Contains(signal, StringComparer.OrdinalIgnoreCase)))
+            {
+                return task;
+            }
+        }
+
+        if (normalized.Contains("scan", StringComparison.OrdinalIgnoreCase))
+        {
+            return "analysis";
+        }
+
+        return null;
+    }
+
+    private static string? ExtractPath(string objective)
+    {
+        var match = FilePattern.Match(objective);
+        return match.Success ? match.Groups["path"].Value : null;
+    }
+
+    private static string? ExtractLanguage(string normalizedObjective, string? path)
+    {
+        var languageMatch = LanguagePattern.Match(normalizedObjective);
+        if (languageMatch.Success)
+        {
+            return NormalizeLanguage(languageMatch.Value);
+        }
+
+        if (!string.IsNullOrEmpty(path))
+        {
+            var extension = ExtractExtension(path);
+            return extension switch
+            {
+                ".cs" or ".csproj" or ".sln" => "csharp",
+                ".fs" => "fsharp",
+                ".vb" => "vbnet",
+                ".py" => "python",
+                ".js" or ".jsx" => "javascript",
+                ".ts" or ".tsx" => "typescript",
+                ".java" => "java",
+                ".kt" or ".kts" => "kotlin",
+                ".go" => "go",
+                ".rs" => "rust",
+                ".php" => "php",
+                ".rb" => "ruby",
+                _ => null,
+            };
+        }
+
+        return null;
+    }
+
+    private static string NormalizeLanguage(string language)
+    {
+        return language.ToLowerInvariant() switch
+        {
+            "c#" or "csharp" or "dotnet" => "csharp",
+            "f#" => "fsharp",
+            _ => language.ToLowerInvariant(),
+        };
+    }
+
+    private static string? ExtractExtension(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return null;
+        }
+
+        var index = path.LastIndexOf('.');
+        return index >= 0 ? path[index..].ToLowerInvariant() : null;
+    }
+
+    private static IReadOnlyDictionary<string, string> BuildParameters(string? path, string? extension, string? language)
+    {
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        if (!string.IsNullOrWhiteSpace(path))
+        {
+            result["target"] = path;
+        }
+
+        if (!string.IsNullOrWhiteSpace(extension))
+        {
+            result["extension"] = extension.TrimStart('.');
+        }
+
+        if (!string.IsNullOrWhiteSpace(language))
+        {
+            result["language"] = language;
+        }
+
+        return result;
+    }
+}

--- a/src/Application/Tools/McpToolDescriptor.cs
+++ b/src/Application/Tools/McpToolDescriptor.cs
@@ -1,0 +1,42 @@
+using RapidCli.Domain.Interfaces;
+using RapidCli.Domain.Models;
+
+namespace RapidCli.Application.Tools;
+
+/// <summary>
+/// Represents a tool entry along with the provider that can execute it and its availability state.
+/// </summary>
+public sealed class McpToolDescriptor
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="McpToolDescriptor"/> class.
+    /// </summary>
+    public McpToolDescriptor(McpToolConfiguration configuration, IAgentToolProvider? provider, ToolAvailability availability)
+    {
+        Configuration = configuration;
+        Provider = provider;
+        Availability = availability;
+    }
+
+    /// <summary>
+    /// Gets the raw configuration entry.
+    /// </summary>
+    public McpToolConfiguration Configuration { get; }
+
+    /// <summary>
+    /// Gets the provider instance capable of executing the tool.
+    /// </summary>
+    public IAgentToolProvider? Provider { get; }
+
+    /// <summary>
+    /// Gets the availability state.
+    /// </summary>
+    public ToolAvailability Availability { get; }
+
+    /// <summary>
+    /// Gets the display name to render to end users.
+    /// </summary>
+    public string DisplayName => string.IsNullOrWhiteSpace(Configuration.DisplayName)
+        ? Configuration.Name
+        : Configuration.DisplayName!;
+}

--- a/src/Application/Tools/McpToolRegistry.cs
+++ b/src/Application/Tools/McpToolRegistry.cs
@@ -1,0 +1,244 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using RapidCli.Application.Configurations;
+using RapidCli.Domain.Interfaces;
+using RapidCli.Domain.Models;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace RapidCli.Application.Tools;
+
+/// <summary>
+/// Loads and keeps track of the MCP tools defined in the configuration registry.
+/// </summary>
+public sealed class McpToolRegistry
+{
+    private const string DefaultRegistryFile = "agent.tools.yaml";
+
+    private readonly IEnumerable<IAgentToolProvider> _providers;
+    private readonly ToolingConfiguration _configuration;
+    private readonly ILogger<McpToolRegistry> _logger;
+    private readonly SemaphoreSlim _mutex = new(1, 1);
+    private IReadOnlyList<McpToolDescriptor> _tools = Array.Empty<McpToolDescriptor>();
+    private readonly IDeserializer _deserializer;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="McpToolRegistry"/> class.
+    /// </summary>
+    public McpToolRegistry(IEnumerable<IAgentToolProvider> providers, IOptions<ToolingConfiguration> options, ILogger<McpToolRegistry> logger)
+    {
+        _providers = providers;
+        _configuration = options.Value;
+        _logger = logger;
+        _deserializer = new DeserializerBuilder()
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .IgnoreUnmatchedProperties()
+            .Build();
+    }
+
+    /// <summary>
+    /// Gets the list of tools available in the registry.
+    /// </summary>
+    public IReadOnlyList<McpToolDescriptor> Tools => _tools;
+
+    /// <summary>
+    /// Reloads the registry from disk, refreshing availability information.
+    /// </summary>
+    public async Task ReloadAsync(CancellationToken cancellationToken)
+    {
+        await _mutex.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var path = ResolveRegistryPath();
+            if (!File.Exists(path))
+            {
+                _logger.LogWarning("El archivo de herramientas MCP '{File}' no existe.", path);
+                _tools = Array.Empty<McpToolDescriptor>();
+                return;
+            }
+
+            var yaml = await File.ReadAllTextAsync(path, cancellationToken).ConfigureAwait(false);
+            var document = _deserializer.Deserialize<McpToolRegistryDocument>(yaml) ?? new McpToolRegistryDocument();
+            var descriptors = new List<McpToolDescriptor>();
+
+            foreach (var tool in document.Tools)
+            {
+                if (!tool.Enabled)
+                {
+                    descriptors.Add(new McpToolDescriptor(tool, null, ToolAvailability.Unavailable("Deshabilitado")));
+                    continue;
+                }
+
+                var provider = _providers.FirstOrDefault(p => p.CanHandle(tool));
+                if (provider is null)
+                {
+                    descriptors.Add(new McpToolDescriptor(tool, null, ToolAvailability.Unavailable("Sin proveedor")));
+                    continue;
+                }
+
+                ToolAvailability availability;
+                try
+                {
+                    availability = await provider.GetAvailabilityAsync(tool, cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "No se pudo verificar la disponibilidad de {Tool}", tool.Name);
+                    availability = ToolAvailability.Unavailable(ex.Message);
+                }
+
+                descriptors.Add(new McpToolDescriptor(tool, provider, availability));
+            }
+
+            _tools = descriptors;
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+
+    /// <summary>
+    /// Attempts to resolve the best tool descriptor for the supplied request.
+    /// </summary>
+    public McpToolDescriptor? Resolve(McpToolRequest request, out int score)
+    {
+        score = 0;
+        if (_tools.Count == 0)
+        {
+            return null;
+        }
+
+        McpToolDescriptor? best = null;
+        var bestScore = 0;
+
+        foreach (var descriptor in _tools)
+        {
+            var currentScore = Score(descriptor.Configuration, request);
+            if (currentScore <= 0)
+            {
+                continue;
+            }
+
+            if (!descriptor.Availability.IsAvailable)
+            {
+                continue;
+            }
+
+            if (best is null
+                || currentScore > bestScore
+                || (currentScore == bestScore && ComparePriority(descriptor.Configuration, best.Configuration) < 0))
+            {
+                best = descriptor;
+                bestScore = currentScore;
+            }
+        }
+
+        score = bestScore;
+        return best;
+    }
+
+    private static int ComparePriority(McpToolConfiguration left, McpToolConfiguration right)
+    {
+        var leftPriority = left.Priority ?? int.MaxValue;
+        var rightPriority = right.Priority ?? int.MaxValue;
+        return leftPriority.CompareTo(rightPriority);
+    }
+
+    private static int Score(McpToolConfiguration configuration, McpToolRequest request)
+    {
+        var score = 0;
+
+        if (!string.IsNullOrWhiteSpace(request.Task)
+            && configuration.Tasks.Any(task => string.Equals(task, request.Task, StringComparison.OrdinalIgnoreCase)))
+        {
+            score += 6;
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.Language)
+            && configuration.Languages.Any(lang => string.Equals(lang, request.Language, StringComparison.OrdinalIgnoreCase)))
+        {
+            score += 3;
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.FileExtension)
+            && configuration.FileExtensions.Any(ext => string.Equals(ext.TrimStart('.'), request.FileExtension.TrimStart('.'), StringComparison.OrdinalIgnoreCase)))
+        {
+            score += 2;
+        }
+
+        if (configuration.IntentKeywords.Count > 0)
+        {
+            var matches = configuration.IntentKeywords.Count(keyword => request.ContainsKeyword(keyword));
+            score += matches;
+        }
+
+        if (configuration.Tasks.Any(task => string.Equals(task, "conversion", StringComparison.OrdinalIgnoreCase))
+            && request.Task is null
+            && request.FileExtension is not null)
+        {
+            score += 2;
+        }
+
+        return score;
+    }
+
+    private string ResolveRegistryPath()
+    {
+        var candidate = _configuration.ConfigurationPath;
+        if (string.IsNullOrWhiteSpace(candidate))
+        {
+            candidate = DefaultRegistryFile;
+        }
+
+        if (Path.IsPathRooted(candidate))
+        {
+            return candidate;
+        }
+
+        var baseDirectories = new List<string?>
+        {
+            Directory.GetCurrentDirectory(),
+            AppContext.BaseDirectory,
+        };
+
+        foreach (var directory in EnumerateCandidateDirectories(baseDirectories))
+        {
+            var fullPath = Path.GetFullPath(Path.Combine(directory, candidate));
+            if (File.Exists(fullPath))
+            {
+                return fullPath;
+            }
+        }
+
+        var fallback = baseDirectories.FirstOrDefault(path => !string.IsNullOrWhiteSpace(path))
+                       ?? Directory.GetCurrentDirectory();
+        return Path.GetFullPath(Path.Combine(fallback, candidate));
+    }
+
+    private static IEnumerable<string> EnumerateCandidateDirectories(IEnumerable<string?> baseDirectories)
+    {
+        var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var baseDirectory in baseDirectories)
+        {
+            if (string.IsNullOrWhiteSpace(baseDirectory))
+            {
+                continue;
+            }
+
+            var current = new DirectoryInfo(baseDirectory);
+            while (current is not null && visited.Add(current.FullName))
+            {
+                yield return current.FullName;
+                current = current.Parent;
+            }
+        }
+    }
+}

--- a/src/Application/Tools/McpToolRequest.cs
+++ b/src/Application/Tools/McpToolRequest.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace RapidCli.Application.Tools;
+
+/// <summary>
+/// Represents the normalized information extracted from the user intent.
+/// </summary>
+public sealed class McpToolRequest
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="McpToolRequest"/> class.
+    /// </summary>
+    public McpToolRequest(
+        string originalObjective,
+        string? task,
+        string? language,
+        string? fileExtension,
+        string? targetPath,
+        IReadOnlyCollection<string> keywords,
+        IReadOnlyDictionary<string, string> parameters)
+    {
+        OriginalObjective = originalObjective;
+        Task = task;
+        Language = language;
+        FileExtension = fileExtension;
+        TargetPath = targetPath;
+        Keywords = keywords;
+        Parameters = parameters;
+    }
+
+    /// <summary>
+    /// Gets the original user objective.
+    /// </summary>
+    public string OriginalObjective { get; }
+
+    /// <summary>
+    /// Gets the classified task type such as security or linting.
+    /// </summary>
+    public string? Task { get; }
+
+    /// <summary>
+    /// Gets the detected programming language.
+    /// </summary>
+    public string? Language { get; }
+
+    /// <summary>
+    /// Gets the primary file extension referenced in the request.
+    /// </summary>
+    public string? FileExtension { get; }
+
+    /// <summary>
+    /// Gets the path that appears to be the main subject of the request.
+    /// </summary>
+    public string? TargetPath { get; }
+
+    /// <summary>
+    /// Gets the set of keywords that influenced the classification.
+    /// </summary>
+    public IReadOnlyCollection<string> Keywords { get; }
+
+    /// <summary>
+    /// Gets the extracted parameters.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Parameters { get; }
+
+    /// <summary>
+    /// Determines whether the specified keyword was found during classification.
+    /// </summary>
+    public bool ContainsKeyword(string keyword)
+        => Keywords.Contains(keyword, StringComparer.OrdinalIgnoreCase);
+}

--- a/src/Application/Tools/Providers/CliToolProvider.cs
+++ b/src/Application/Tools/Providers/CliToolProvider.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using RapidCli.Domain.Interfaces;
+using RapidCli.Domain.Models;
+
+namespace RapidCli.Application.Tools.Providers;
+
+/// <summary>
+/// Executes tools that expose a command line interface.
+/// </summary>
+public sealed class CliToolProvider : IAgentToolProvider
+{
+    /// <inheritdoc />
+    public string Name => "cli";
+
+    /// <inheritdoc />
+    public bool CanHandle(McpToolConfiguration configuration)
+        => string.Equals(configuration.Execution.Mode, "cli", StringComparison.OrdinalIgnoreCase)
+           && !string.IsNullOrWhiteSpace(configuration.Execution.Command);
+
+    /// <inheritdoc />
+    public async Task<ToolAvailability> GetAvailabilityAsync(McpToolConfiguration configuration, CancellationToken cancellationToken)
+    {
+        var command = configuration.Execution.Command;
+        if (string.IsNullOrWhiteSpace(command))
+        {
+            return ToolAvailability.Unavailable("Comando no configurado.");
+        }
+
+        var location = await LocateExecutableAsync(command, cancellationToken).ConfigureAwait(false);
+        return location is not null
+            ? ToolAvailability.Available(location)
+            : ToolAvailability.Unavailable($"No se encontró el ejecutable '{command}'.");
+    }
+
+    /// <inheritdoc />
+    public async Task<ToolExecutionResult> ExecuteAsync(McpToolConfiguration configuration, McpToolInvocationContext context, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var command = configuration.Execution.Command;
+        if (string.IsNullOrWhiteSpace(command))
+        {
+            throw new InvalidOperationException("El comando de la herramienta no está configurado.");
+        }
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = command,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        foreach (var argument in ExpandArguments(configuration.Execution.Arguments, context.Parameters))
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        if (!string.IsNullOrWhiteSpace(configuration.Execution.WorkingDirectory))
+        {
+            var workingDirectory = ResolveWorkingDirectory(configuration.Execution.WorkingDirectory);
+            if (!Directory.Exists(workingDirectory))
+            {
+                Directory.CreateDirectory(workingDirectory);
+            }
+
+            startInfo.WorkingDirectory = workingDirectory;
+        }
+
+        foreach (var pair in configuration.Execution.Environment)
+        {
+            startInfo.Environment[pair.Key] = ResolveTokens(pair.Value, context.Parameters);
+        }
+
+        var outputBuilder = new StringBuilder();
+        var errorBuilder = new StringBuilder();
+        var stopwatch = Stopwatch.StartNew();
+
+        using var process = new Process { StartInfo = startInfo };
+        process.OutputDataReceived += (_, args) =>
+        {
+            if (args.Data is not null)
+            {
+                outputBuilder.AppendLine(args.Data);
+            }
+        };
+
+        process.ErrorDataReceived += (_, args) =>
+        {
+            if (args.Data is not null)
+            {
+                errorBuilder.AppendLine(args.Data);
+            }
+        };
+
+        process.Start();
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+        stopwatch.Stop();
+
+        var output = outputBuilder.ToString().Trim();
+        var error = errorBuilder.ToString().Trim();
+
+        return process.ExitCode == 0
+            ? ToolExecutionResult.SuccessResult(output, string.IsNullOrWhiteSpace(error) ? null : error, stopwatch.Elapsed)
+            : ToolExecutionResult.FailureResult(output, string.IsNullOrWhiteSpace(error) ? null : error, stopwatch.Elapsed);
+    }
+
+    private static IEnumerable<string> ExpandArguments(IEnumerable<string> arguments, IReadOnlyDictionary<string, string> parameters)
+    {
+        foreach (var argument in arguments)
+        {
+            yield return ResolveTokens(argument, parameters);
+        }
+    }
+
+    private static string ResolveTokens(string value, IReadOnlyDictionary<string, string> parameters)
+    {
+        var result = value;
+        foreach (var pair in parameters)
+        {
+            result = result.Replace($"{{{pair.Key}}}", pair.Value, StringComparison.OrdinalIgnoreCase);
+        }
+
+        return result;
+    }
+
+    private static string ResolveWorkingDirectory(string path)
+        => Path.IsPathRooted(path)
+            ? path
+            : Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), path));
+
+    private static async Task<string?> LocateExecutableAsync(string command, CancellationToken cancellationToken)
+    {
+        var lookupCommand = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "where" : "which";
+        try
+        {
+            using var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = lookupCommand,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                },
+            };
+
+            process.StartInfo.ArgumentList.Add(command);
+            process.Start();
+            var output = await process.StandardOutput.ReadToEndAsync().ConfigureAwait(false);
+            await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+
+            if (process.ExitCode == 0)
+            {
+                var firstLine = output.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+                return firstLine;
+            }
+        }
+        catch
+        {
+            // Ignored: availability checks are best effort.
+        }
+
+        return null;
+    }
+}

--- a/src/Application/Tools/Providers/YamlJsonToolProvider.cs
+++ b/src/Application/Tools/Providers/YamlJsonToolProvider.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using RapidCli.Domain.Interfaces;
+using RapidCli.Domain.Models;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace RapidCli.Application.Tools.Providers;
+
+/// <summary>
+/// Provides YAML ↔ JSON conversions using an in-process handler.
+/// </summary>
+public sealed class YamlJsonToolProvider : IAgentToolProvider
+{
+    private readonly IDeserializer _deserializer;
+    private readonly ISerializer _serializer;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="YamlJsonToolProvider"/> class.
+    /// </summary>
+    public YamlJsonToolProvider()
+    {
+        _deserializer = new DeserializerBuilder()
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .IgnoreUnmatchedProperties()
+            .Build();
+
+        _serializer = new SerializerBuilder()
+            .JsonCompatible()
+            .Build();
+    }
+
+    /// <inheritdoc />
+    public string Name => "builtin.yaml-json";
+
+    /// <inheritdoc />
+    public bool CanHandle(McpToolConfiguration configuration)
+        => string.Equals(configuration.Execution.Mode, "builtin", StringComparison.OrdinalIgnoreCase)
+           && string.Equals(configuration.Execution.Handler, "yaml-json", StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public Task<ToolAvailability> GetAvailabilityAsync(McpToolConfiguration configuration, CancellationToken cancellationToken)
+        => Task.FromResult(ToolAvailability.Available("Integrado"));
+
+    /// <inheritdoc />
+    public async Task<ToolExecutionResult> ExecuteAsync(McpToolConfiguration configuration, McpToolInvocationContext context, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        try
+        {
+            var direction = configuration.Metadata.TryGetValue("direction", out var value)
+                ? value
+                : "yaml-to-json";
+
+            var targetPath = ResolveTargetPath(context);
+            var content = await File.ReadAllTextAsync(targetPath, cancellationToken).ConfigureAwait(false);
+
+            string output = direction switch
+            {
+                "json-to-yaml" => ConvertJsonToYaml(content),
+                _ => ConvertYamlToJson(content),
+            };
+
+            stopwatch.Stop();
+            return ToolExecutionResult.SuccessResult(output, null, stopwatch.Elapsed);
+        }
+        catch (Exception ex)
+        {
+            stopwatch.Stop();
+            return ToolExecutionResult.FailureResult(string.Empty, ex.Message, stopwatch.Elapsed);
+        }
+    }
+
+    private static string ResolveTargetPath(McpToolInvocationContext context)
+    {
+        if (!string.IsNullOrWhiteSpace(context.TargetPath) && File.Exists(context.TargetPath))
+        {
+            return context.TargetPath;
+        }
+
+        if (context.Parameters.TryGetValue("target", out var target) && !string.IsNullOrWhiteSpace(target))
+        {
+            var fullPath = Path.IsPathRooted(target)
+                ? target
+                : Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), target));
+
+            if (File.Exists(fullPath))
+            {
+                return fullPath;
+            }
+        }
+
+        throw new FileNotFoundException("No se pudo determinar el archivo a convertir.");
+    }
+
+    private string ConvertYamlToJson(string yaml)
+    {
+        var yamlObject = _deserializer.Deserialize<object?>(yaml);
+        var json = JsonSerializer.Serialize(yamlObject, new JsonSerializerOptions
+        {
+            WriteIndented = true,
+        });
+        return json;
+    }
+
+    private string ConvertJsonToYaml(string json)
+    {
+        var jsonObject = JsonSerializer.Deserialize<object?>(json);
+        var yaml = _serializer.Serialize(jsonObject);
+        return yaml;
+    }
+}

--- a/src/Application/Tools/ToolOrchestrationResult.cs
+++ b/src/Application/Tools/ToolOrchestrationResult.cs
@@ -1,0 +1,97 @@
+using RapidCli.Domain.Models;
+
+namespace RapidCli.Application.Tools;
+
+/// <summary>
+/// Represents the result of attempting to orchestrate an MCP tool before delegating to the agent.
+/// </summary>
+public sealed class ToolOrchestrationResult
+{
+    private ToolOrchestrationResult(
+        string originalObjective,
+        string agentObjective,
+        bool toolExecuted,
+        bool bypassAgent,
+        string? responseText,
+        McpToolDescriptor? descriptor,
+        ToolExecutionResult? executionResult,
+        string? message)
+    {
+        OriginalObjective = originalObjective;
+        AgentObjective = agentObjective;
+        ToolExecuted = toolExecuted;
+        BypassAgent = bypassAgent;
+        ResponseText = responseText;
+        Descriptor = descriptor;
+        ExecutionResult = executionResult;
+        Message = message;
+    }
+
+    /// <summary>
+    /// Gets the original message provided by the user.
+    /// </summary>
+    public string OriginalObjective { get; }
+
+    /// <summary>
+    /// Gets the objective that should be forwarded to the autonomous agent.
+    /// </summary>
+    public string AgentObjective { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether a tool was executed.
+    /// </summary>
+    public bool ToolExecuted { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the agent should be bypassed because the tool already produced a final answer.
+    /// </summary>
+    public bool BypassAgent { get; }
+
+    /// <summary>
+    /// Gets the response text to return directly to the user when <see cref="BypassAgent"/> is true.
+    /// </summary>
+    public string? ResponseText { get; }
+
+    /// <summary>
+    /// Gets the descriptor of the tool that was chosen.
+    /// </summary>
+    public McpToolDescriptor? Descriptor { get; }
+
+    /// <summary>
+    /// Gets the execution result returned by the provider.
+    /// </summary>
+    public ToolExecutionResult? ExecutionResult { get; }
+
+    /// <summary>
+    /// Gets an optional informational message that should be rendered to the user before the agent response.
+    /// </summary>
+    public string? Message { get; }
+
+    /// <summary>
+    /// Creates a result indicating that no tool was executed and the agent should receive the original objective.
+    /// </summary>
+    public static ToolOrchestrationResult Skip(string objective, string? message = null)
+        => new(objective, objective, false, false, null, null, null, message);
+
+    /// <summary>
+    /// Creates a result that forwards the provided objective to the agent after executing a tool.
+    /// </summary>
+    public static ToolOrchestrationResult Forward(
+        string originalObjective,
+        string agentObjective,
+        McpToolDescriptor descriptor,
+        ToolExecutionResult executionResult,
+        string? message)
+        => new(originalObjective, agentObjective, true, false, null, descriptor, executionResult, message);
+
+    /// <summary>
+    /// Creates a result that bypasses the agent because the tool produced the final answer.
+    /// </summary>
+    public static ToolOrchestrationResult Complete(
+        string originalObjective,
+        McpToolDescriptor descriptor,
+        ToolExecutionResult executionResult,
+        string responseText,
+        string? message)
+        => new(originalObjective, originalObjective, true, true, responseText, descriptor, executionResult, message);
+}

--- a/src/Application/Tools/ToolOrchestrator.cs
+++ b/src/Application/Tools/ToolOrchestrator.cs
@@ -1,0 +1,204 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using RapidCli.Application.Configurations;
+using RapidCli.Domain.Models;
+
+namespace RapidCli.Application.Tools;
+
+/// <summary>
+/// Coordinates the selection and execution of MCP tools before delegating to the autonomous agent.
+/// </summary>
+public sealed class ToolOrchestrator
+{
+    private readonly McpToolRegistry _registry;
+    private readonly McpIntentClassifier _classifier;
+    private readonly ToolingConfiguration _configuration;
+    private readonly ILogger<ToolOrchestrator> _logger;
+    private bool _initialized;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ToolOrchestrator"/> class.
+    /// </summary>
+    public ToolOrchestrator(
+        McpToolRegistry registry,
+        McpIntentClassifier classifier,
+        IOptions<ToolingConfiguration> options,
+        ILogger<ToolOrchestrator> logger)
+    {
+        _registry = registry;
+        _classifier = classifier;
+        _configuration = options.Value;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Ensures the registry is loaded at least once.
+    /// </summary>
+    public async Task InitializeAsync(CancellationToken cancellationToken)
+    {
+        if (_initialized)
+        {
+            return;
+        }
+
+        await _registry.ReloadAsync(cancellationToken).ConfigureAwait(false);
+        _initialized = true;
+    }
+
+    /// <summary>
+    /// Gets the registered tools along with their availability state.
+    /// </summary>
+    public IReadOnlyList<McpToolDescriptor> GetRegisteredTools()
+        => _registry.Tools;
+
+    /// <summary>
+    /// Attempts to orchestrate a tool for the specified objective.
+    /// </summary>
+    public async Task<ToolOrchestrationResult> TryOrchestrateAsync(string objective, CancellationToken cancellationToken)
+    {
+        if (!_initialized)
+        {
+            await InitializeAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        if (!_configuration.AutoExecute)
+        {
+            return ToolOrchestrationResult.Skip(objective, "La ejecución automática de MCP está deshabilitada.");
+        }
+
+        var request = _classifier.Classify(objective);
+        var descriptor = _registry.Resolve(request, out var score);
+        if (descriptor is null || score <= 0)
+        {
+            return ToolOrchestrationResult.Skip(objective);
+        }
+
+        if (descriptor.Provider is null)
+        {
+            return ToolOrchestrationResult.Skip(objective, $"No hay proveedor registrado para {descriptor.DisplayName}.");
+        }
+
+        if (!descriptor.Availability.IsAvailable)
+        {
+            var reason = descriptor.Availability.Detail ?? "herramienta no disponible";
+            return ToolOrchestrationResult.Skip(objective, $"{descriptor.DisplayName}: {reason}");
+        }
+
+        var contextParameters = new Dictionary<string, string>(request.Parameters, StringComparer.OrdinalIgnoreCase)
+        {
+            ["objective"] = objective,
+        };
+
+        var resolvedTarget = ResolveTargetPath(request.TargetPath);
+        if (!string.IsNullOrWhiteSpace(resolvedTarget))
+        {
+            contextParameters["target"] = resolvedTarget;
+        }
+
+        var context = new McpToolInvocationContext(
+            objective,
+            resolvedTarget,
+            request.Language,
+            contextParameters);
+
+        ToolExecutionResult execution;
+        try
+        {
+            execution = await descriptor.Provider
+                .ExecuteAsync(descriptor.Configuration, context, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "La herramienta {Tool} falló durante la ejecución", descriptor.DisplayName);
+            return ToolOrchestrationResult.Skip(objective, $"{descriptor.DisplayName} falló: {ex.Message}");
+        }
+
+        var normalizedOutput = NormalizeOutput(execution.Output);
+        execution = execution.Success
+            ? ToolExecutionResult.SuccessResult(normalizedOutput, execution.Error, execution.Duration)
+            : ToolExecutionResult.FailureResult(normalizedOutput, execution.Error, execution.Duration);
+
+        if (!execution.Success)
+        {
+            var failure = !string.IsNullOrWhiteSpace(execution.Error)
+                ? execution.Error
+                : "La herramienta devolvió un código de salida distinto de cero.";
+            return ToolOrchestrationResult.Skip(objective, $"{descriptor.DisplayName}: {failure}");
+        }
+
+        if (!descriptor.Configuration.ForwardResultToAgent)
+        {
+            return ToolOrchestrationResult.Complete(objective, descriptor, execution, execution.Output, BuildMessage(descriptor));
+        }
+
+        var agentObjective = BuildAgentObjective(objective, descriptor, execution.Output, execution.Error);
+        return ToolOrchestrationResult.Forward(objective, agentObjective, descriptor, execution, BuildMessage(descriptor));
+    }
+
+    private string? ResolveTargetPath(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return null;
+        }
+
+        if (Path.IsPathRooted(path))
+        {
+            return path;
+        }
+
+        return Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), path));
+    }
+
+    private string NormalizeOutput(string output)
+    {
+        if (string.IsNullOrWhiteSpace(output))
+        {
+            return output;
+        }
+
+        var trimmed = output.Length > _configuration.MaxOutputCharacters
+            ? output[.._configuration.MaxOutputCharacters]
+            : output;
+        return trimmed.Trim();
+    }
+
+    private static string BuildMessage(McpToolDescriptor descriptor)
+        => $"Se utilizó la herramienta MCP '{descriptor.DisplayName}'.";
+
+    private static string BuildAgentObjective(string originalObjective, McpToolDescriptor descriptor, string output, string? error)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("Actúa como un analista senior.");
+        builder.AppendLine("Interpreta los resultados de la herramienta MCP ejecutada automáticamente y responde en español.");
+        builder.AppendLine();
+        builder.AppendLine($"Solicitud original: {originalObjective}");
+        builder.AppendLine();
+        builder.AppendLine($"Herramienta: {descriptor.DisplayName} ({descriptor.Configuration.Type})");
+        builder.AppendLine("Salida:");
+        builder.AppendLine("```text");
+        builder.AppendLine(string.IsNullOrWhiteSpace(output) ? "<sin salida>" : output);
+        builder.AppendLine("```");
+
+        if (!string.IsNullOrWhiteSpace(error))
+        {
+            builder.AppendLine();
+            builder.AppendLine("Registro de error:");
+            builder.AppendLine("```text");
+            builder.AppendLine(error!);
+            builder.AppendLine("```");
+        }
+
+        builder.AppendLine();
+        builder.AppendLine("Incluye recomendaciones accionables cuando aplique.");
+        return builder.ToString();
+    }
+}

--- a/src/CLI/Program.cs
+++ b/src/CLI/Program.cs
@@ -51,6 +51,7 @@ rootCommand.SetHandler(async (InvocationContext context) =>
     });
 
     builder.Services.Configure<ChatConfiguration>(builder.Configuration.GetSection("Chat"));
+    builder.Services.Configure<ToolingConfiguration>(builder.Configuration.GetSection("Tools"));
     builder.Services.AddApplicationServices();
     builder.Services.AddInfrastructure(builder.Configuration);
     builder.Services.AddSingleton<CliRunner>();

--- a/src/Domain/Interfaces/IAgentToolProvider.cs
+++ b/src/Domain/Interfaces/IAgentToolProvider.cs
@@ -1,0 +1,38 @@
+using System.Threading;
+using System.Threading.Tasks;
+using RapidCli.Domain.Models;
+
+namespace RapidCli.Domain.Interfaces;
+
+/// <summary>
+/// Provides the contract required to execute external Model Context Protocol tools.
+/// </summary>
+public interface IAgentToolProvider
+{
+    /// <summary>
+    /// Gets the unique name of the provider implementation.
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Determines whether the provider can handle the supplied tool configuration.
+    /// </summary>
+    /// <param name="configuration">The tool configuration to evaluate.</param>
+    /// <returns><c>true</c> when the provider can execute the tool; otherwise, <c>false</c>.</returns>
+    bool CanHandle(McpToolConfiguration configuration);
+
+    /// <summary>
+    /// Computes the availability state for the specified tool.
+    /// </summary>
+    /// <param name="configuration">The tool configuration.</param>
+    /// <param name="cancellationToken">Token used to cancel the check.</param>
+    Task<ToolAvailability> GetAvailabilityAsync(McpToolConfiguration configuration, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Executes the tool using the provided context.
+    /// </summary>
+    /// <param name="configuration">The tool configuration.</param>
+    /// <param name="context">Invocation context extracted from the user intent.</param>
+    /// <param name="cancellationToken">Token used to cancel the execution.</param>
+    Task<ToolExecutionResult> ExecuteAsync(McpToolConfiguration configuration, McpToolInvocationContext context, CancellationToken cancellationToken);
+}

--- a/src/Domain/Models/McpToolConfiguration.cs
+++ b/src/Domain/Models/McpToolConfiguration.cs
@@ -1,0 +1,150 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace RapidCli.Domain.Models;
+
+/// <summary>
+/// Represents a Model Context Protocol tool entry loaded from the registry configuration file.
+/// </summary>
+public sealed class McpToolConfiguration
+{
+    /// <summary>
+    /// Gets or sets the internal identifier of the tool.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the user facing display name.
+    /// </summary>
+    [JsonPropertyName("display_name")]
+    public string? DisplayName { get; set; }
+        = null;
+
+    /// <summary>
+    /// Gets or sets the general tool type (for example security, linting, docs, etc.).
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
+        = null;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the tool is enabled.
+    /// </summary>
+    [JsonPropertyName("enabled")]
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the optional priority used to break ties when resolving tools.
+    /// Lower values take precedence.
+    /// </summary>
+    [JsonPropertyName("priority")]
+    public int? Priority { get; set; }
+        = null;
+
+    /// <summary>
+    /// Gets or sets the execution metadata that describes how the tool should be invoked.
+    /// </summary>
+    [JsonPropertyName("execution")]
+    public McpToolExecution Execution { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the list of high level tasks supported by the tool (security, linting, conversion, etc.).
+    /// </summary>
+    [JsonPropertyName("tasks")]
+    public List<string> Tasks { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the languages or ecosystems supported by the tool.
+    /// </summary>
+    [JsonPropertyName("languages")]
+    public List<string> Languages { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the file extensions that the tool understands.
+    /// </summary>
+    [JsonPropertyName("file_extensions")]
+    public List<string> FileExtensions { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the keywords that should trigger the tool when found in the user intent.
+    /// </summary>
+    [JsonPropertyName("intent_keywords")]
+    public List<string> IntentKeywords { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets arbitrary metadata passed to the provider.
+    /// </summary>
+    [JsonPropertyName("metadata")]
+    public Dictionary<string, string> Metadata { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets an optional description of the capabilities offered by the tool.
+    /// </summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+        = null;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the raw tool output must be interpreted by the agent afterwards.
+    /// </summary>
+    [JsonPropertyName("forward_result_to_agent")]
+    public bool ForwardResultToAgent { get; set; } = true;
+}
+
+/// <summary>
+/// Encapsulates the execution contract for a tool entry.
+/// </summary>
+public sealed class McpToolExecution
+{
+    /// <summary>
+    /// Gets or sets the execution mode (cli, http, builtin, socket, etc.).
+    /// </summary>
+    [JsonPropertyName("mode")]
+    public string Mode { get; set; } = "cli";
+
+    /// <summary>
+    /// Gets or sets the command or endpoint associated with the tool.
+    /// </summary>
+    [JsonPropertyName("command")]
+    public string? Command { get; set; }
+        = null;
+
+    /// <summary>
+    /// Gets or sets the command arguments.
+    /// </summary>
+    [JsonPropertyName("arguments")]
+    public List<string> Arguments { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets an optional handler identifier used by builtin providers.
+    /// </summary>
+    [JsonPropertyName("handler")]
+    public string? Handler { get; set; }
+        = null;
+
+    /// <summary>
+    /// Gets or sets the working directory used when running the tool.
+    /// </summary>
+    [JsonPropertyName("working_directory")]
+    public string? WorkingDirectory { get; set; }
+        = null;
+
+    /// <summary>
+    /// Gets or sets optional environment variables that should be present when executing the tool.
+    /// </summary>
+    [JsonPropertyName("environment")]
+    public Dictionary<string, string> Environment { get; set; } = new();
+}
+
+/// <summary>
+/// Represents a typed model for the tool registry file.
+/// </summary>
+public sealed class McpToolRegistryDocument
+{
+    /// <summary>
+    /// Gets or sets the collection of tools defined in the registry.
+    /// </summary>
+    [JsonPropertyName("tools")]
+    public List<McpToolConfiguration> Tools { get; set; } = new();
+}

--- a/src/Domain/Models/McpToolInvocationContext.cs
+++ b/src/Domain/Models/McpToolInvocationContext.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+
+namespace RapidCli.Domain.Models;
+
+/// <summary>
+/// Provides contextual information for tool execution based on the user request.
+/// </summary>
+public sealed class McpToolInvocationContext
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="McpToolInvocationContext"/> class.
+    /// </summary>
+    public McpToolInvocationContext(
+        string objective,
+        string? targetPath,
+        string? language,
+        IReadOnlyDictionary<string, string> parameters)
+    {
+        Objective = objective;
+        TargetPath = targetPath;
+        Language = language;
+        Parameters = parameters;
+    }
+
+    /// <summary>
+    /// Gets the normalized user objective that originated the invocation.
+    /// </summary>
+    public string Objective { get; }
+
+    /// <summary>
+    /// Gets the primary file or resource path associated with the request, when available.
+    /// </summary>
+    public string? TargetPath { get; }
+
+    /// <summary>
+    /// Gets the language that best matches the request context.
+    /// </summary>
+    public string? Language { get; }
+
+    /// <summary>
+    /// Gets additional parameters extracted from the intent such as file extensions or auxiliary flags.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Parameters { get; }
+}

--- a/src/Domain/Models/ToolAvailability.cs
+++ b/src/Domain/Models/ToolAvailability.cs
@@ -1,0 +1,45 @@
+using System.Text.Json.Serialization;
+
+namespace RapidCli.Domain.Models;
+
+/// <summary>
+/// Represents the availability status of an MCP tool.
+/// </summary>
+public sealed class ToolAvailability
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ToolAvailability"/> class.
+    /// </summary>
+    /// <param name="isAvailable">Whether the tool can be executed.</param>
+    /// <param name="detail">Optional descriptive detail.</param>
+    [JsonConstructor]
+    public ToolAvailability(bool isAvailable, string? detail = null)
+    {
+        IsAvailable = isAvailable;
+        Detail = detail;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether the tool can be executed.
+    /// </summary>
+    [JsonPropertyName("available")]
+    public bool IsAvailable { get; }
+
+    /// <summary>
+    /// Gets a human readable description of the availability state.
+    /// </summary>
+    [JsonPropertyName("detail")]
+    public string? Detail { get; }
+
+    /// <summary>
+    /// Creates an availability instance marked as available.
+    /// </summary>
+    public static ToolAvailability Available(string? detail = null)
+        => new(true, detail);
+
+    /// <summary>
+    /// Creates an availability instance marked as unavailable.
+    /// </summary>
+    public static ToolAvailability Unavailable(string? detail = null)
+        => new(false, detail);
+}

--- a/src/Domain/Models/ToolExecutionResult.cs
+++ b/src/Domain/Models/ToolExecutionResult.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace RapidCli.Domain.Models;
+
+/// <summary>
+/// Represents the outcome of executing a tool.
+/// </summary>
+public sealed class ToolExecutionResult
+{
+    private ToolExecutionResult(bool success, string output, string? error, TimeSpan duration)
+    {
+        Success = success;
+        Output = output;
+        Error = error;
+        Duration = duration;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether the tool finished successfully.
+    /// </summary>
+    [JsonPropertyName("success")]
+    public bool Success { get; }
+
+    /// <summary>
+    /// Gets the standard output emitted by the tool.
+    /// </summary>
+    [JsonPropertyName("output")]
+    public string Output { get; }
+
+    /// <summary>
+    /// Gets the standard error emitted by the tool, if any.
+    /// </summary>
+    [JsonPropertyName("error")]
+    public string? Error { get; }
+
+    /// <summary>
+    /// Gets the total execution duration.
+    /// </summary>
+    [JsonPropertyName("duration")]
+    public TimeSpan Duration { get; }
+
+    /// <summary>
+    /// Creates a successful tool execution result.
+    /// </summary>
+    public static ToolExecutionResult SuccessResult(string output, string? error, TimeSpan duration)
+        => new(true, output, error, duration);
+
+    /// <summary>
+    /// Creates a failing tool execution result.
+    /// </summary>
+    public static ToolExecutionResult FailureResult(string output, string? error, TimeSpan duration)
+        => new(false, output, error, duration);
+}


### PR DESCRIPTION
## Summary
- search multiple base directories when resolving the MCP registry file
- allow debugging builds to locate the default agent.tools.yaml shipped at the repo root

## Testing
- not run (infrastructure limitation)


------
https://chatgpt.com/codex/tasks/task_e_68d6d8802cec832397a938af2c3af147