### PR TITLE
Implement persistent conversation sessions and reasoning display

### DIFF
--- a/src/Application/Services/ChatService.cs
+++ b/src/Application/Services/ChatService.cs
@@ -1,9 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using RapidCli.Application.Configurations;
 using RapidCli.Application.Conversation;
+using RapidCli.Application.Sessions;
 using RapidCli.Domain.Interfaces;
 using RapidCli.Domain.Models;
 
@@ -14,10 +21,20 @@ namespace RapidCli.Application.Services;
 /// </summary>
 public sealed class ChatService
 {
+    private const int EstimatedTokensPerCharacter = 4;
+    private const int ConversationTokenLimit = 6000;
+    private const int PreserveTailMessageCount = 6;
+    private const int ThoughtLogLimit = 50;
+
     private readonly IAIClient _client;
     private readonly ConversationManager _conversationManager;
     private readonly ConfigurationService _configurationService;
+    private readonly SessionStorageService _sessionStorage;
     private readonly ILogger<ChatService> _logger;
+    private readonly SemaphoreSlim _sessionSemaphore = new(1, 1);
+
+    private ConversationSession? _currentSession;
+    private bool _initialized;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ChatService"/> class.
@@ -25,17 +42,207 @@ public sealed class ChatService
     /// <param name="client">The AI client implementation responsible for HTTP interactions.</param>
     /// <param name="conversationManager">The component that keeps track of the conversation history.</param>
     /// <param name="configurationService">The provider for configurable generation parameters.</param>
+    /// <param name="sessionStorage">Component responsible for persisting sessions.</param>
     /// <param name="logger">The logger used for diagnostic messages.</param>
     public ChatService(
         IAIClient client,
         ConversationManager conversationManager,
         ConfigurationService configurationService,
+        SessionStorageService sessionStorage,
         ILogger<ChatService> logger)
     {
         _client = client;
         _conversationManager = conversationManager;
         _configurationService = configurationService;
+        _sessionStorage = sessionStorage;
         _logger = logger;
+    }
+
+    /// <summary>
+    /// Gets the currently active session.
+    /// </summary>
+    public ConversationSession CurrentSession
+        => _currentSession ?? throw new InvalidOperationException("The chat service has not been initialised.");
+
+    /// <summary>
+    /// Ensures that a session exists and is persisted on disk.
+    /// </summary>
+    public async Task InitializeSessionAsync(CancellationToken cancellationToken = default)
+    {
+        if (_initialized)
+        {
+            return;
+        }
+
+        await _sessionSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_initialized)
+            {
+                return;
+            }
+
+            _currentSession = _sessionStorage.CreateSession();
+            _conversationManager.Clear();
+            _initialized = true;
+            RefreshConfigurationSnapshot();
+            await PersistAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _sessionSemaphore.Release();
+        }
+    }
+
+    /// <summary>
+    /// Starts a new session, optionally using the provided identifier.
+    /// </summary>
+    public async Task ResetAsync(string? sessionId = null, CancellationToken cancellationToken = default)
+    {
+        await _sessionSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            _currentSession = _sessionStorage.CreateSession(sessionId);
+            _conversationManager.Clear();
+            _initialized = true;
+            RefreshConfigurationSnapshot();
+            await PersistAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _sessionSemaphore.Release();
+        }
+    }
+
+    /// <summary>
+    /// Loads the specified session from disk.
+    /// </summary>
+    /// <returns><c>true</c> when the session exists and was loaded successfully.</returns>
+    public async Task<bool> LoadSessionAsync(string sessionId, CancellationToken cancellationToken = default)
+    {
+        await InitializeSessionAsync(cancellationToken).ConfigureAwait(false);
+
+        var loaded = await _sessionStorage.LoadAsync(sessionId, cancellationToken).ConfigureAwait(false);
+        if (loaded is null)
+        {
+            return false;
+        }
+
+        await _sessionSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            NormalizeSession(loaded);
+            _currentSession = loaded;
+            _conversationManager.Load(loaded.Messages);
+            await EnsureHistoryWithinLimitsAsync(cancellationToken).ConfigureAwait(false);
+            RefreshConfigurationSnapshot();
+            await PersistAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _sessionSemaphore.Release();
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Stores a copy of the current session using the provided identifier.
+    /// </summary>
+    /// <returns>The identifier used to store the snapshot.</returns>
+    public async Task<string> SaveSnapshotAsync(string newIdentifier, CancellationToken cancellationToken = default)
+    {
+        await InitializeSessionAsync(cancellationToken).ConfigureAwait(false);
+        var session = CurrentSession;
+        return await _sessionStorage.SaveAsAsync(session, newIdentifier, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Gets the conversation history.
+    /// </summary>
+    public IReadOnlyList<ChatMessage> GetHistory()
+        => _conversationManager.Messages;
+
+    /// <summary>
+    /// Adds a user message to the history and persists the session.
+    /// </summary>
+    public Task AddUserMessageAsync(string content, CancellationToken cancellationToken = default)
+        => AddMessageAsync(new ChatMessage { Role = "user", Content = content }, cancellationToken);
+
+    /// <summary>
+    /// Adds an assistant message to the history and persists the session.
+    /// </summary>
+    public Task AddAssistantMessageAsync(string content, CancellationToken cancellationToken = default)
+        => AddMessageAsync(new ChatMessage { Role = "assistant", Content = content }, cancellationToken);
+
+    /// <summary>
+    /// Replaces the conversation history with the supplied messages and persists the session.
+    /// </summary>
+    public async Task SetHistoryAsync(IEnumerable<ChatMessage> messages, CancellationToken cancellationToken = default)
+    {
+        await InitializeSessionAsync(cancellationToken).ConfigureAwait(false);
+        _conversationManager.Load(messages);
+        await EnsureHistoryWithinLimitsAsync(cancellationToken).ConfigureAwait(false);
+        await PersistAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Records a reasoning trace for the agent and persists it.
+    /// </summary>
+    public async Task RecordThoughtAsync(string thought, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(thought))
+        {
+            return;
+        }
+
+        await InitializeSessionAsync(cancellationToken).ConfigureAwait(false);
+        AppendThoughtInternal(thought);
+        await PersistAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Registers the usage of a tool during the current session.
+    /// </summary>
+    public void RegisterToolUsage(string toolName)
+    {
+        if (string.IsNullOrWhiteSpace(toolName) || _currentSession is null)
+        {
+            return;
+        }
+
+        if (!_currentSession.ToolsUsed.Contains(toolName, StringComparer.OrdinalIgnoreCase))
+        {
+            _currentSession.ToolsUsed.Add(toolName);
+        }
+
+        if (!_currentSession.AgentState.ActiveTools.Contains(toolName, StringComparer.OrdinalIgnoreCase))
+        {
+            _currentSession.AgentState.ActiveTools.Add(toolName);
+        }
+    }
+
+    /// <summary>
+    /// Updates the agent state with the provided tool invocations.
+    /// </summary>
+    public void RegisterAgentToolInvocations(IEnumerable<AgentToolInvocation> invocations)
+    {
+        if (_currentSession is null)
+        {
+            return;
+        }
+
+        foreach (var invocation in invocations)
+        {
+            RegisterToolUsage(invocation.ToolName);
+            foreach (var path in ExtractPaths(invocation))
+            {
+                if (!_currentSession.AgentState.LoadedFiles.Contains(path, StringComparer.OrdinalIgnoreCase))
+                {
+                    _currentSession.AgentState.LoadedFiles.Add(path);
+                }
+            }
+        }
     }
 
     /// <summary>
@@ -50,14 +257,7 @@ public sealed class ChatService
         bool? streamOverride = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        _logger.LogInformation("Dispatching user message with {TokenCount} characters", userMessage.Length);
-
-        var message = new ChatMessage
-        {
-            Role = "user",
-            Content = userMessage,
-        };
-        _conversationManager.AddMessage(message);
+        await AddUserMessageAsync(userMessage, cancellationToken).ConfigureAwait(false);
 
         var request = BuildRequest(streamOverride);
         _logger.LogDebug("Prepared request for model {Model} with streaming {Stream}", request.Model, request.Stream);
@@ -81,12 +281,7 @@ public sealed class ChatService
                 }
             }
 
-            var assistantMessage = new ChatMessage
-            {
-                Role = "assistant",
-                Content = builder.ToString(),
-            };
-            _conversationManager.AddMessage(assistantMessage);
+            await AddAssistantMessageAsync(builder.ToString(), cancellationToken).ConfigureAwait(false);
         }
         else
         {
@@ -97,33 +292,220 @@ public sealed class ChatService
                 yield return text;
             }
 
-            var assistantMessage = new ChatMessage
-            {
-                Role = "assistant",
-                Content = text,
-            };
-            _conversationManager.AddMessage(assistantMessage);
+            await AddAssistantMessageAsync(text, cancellationToken).ConfigureAwait(false);
         }
     }
 
-    /// <summary>
-    /// Gets the conversation history.
-    /// </summary>
-    public IReadOnlyList<ChatMessage> GetHistory()
-        => _conversationManager.Messages;
+    private async Task AddMessageAsync(ChatMessage message, CancellationToken cancellationToken)
+    {
+        await InitializeSessionAsync(cancellationToken).ConfigureAwait(false);
+        _conversationManager.AddMessage(message);
+        await EnsureHistoryWithinLimitsAsync(cancellationToken).ConfigureAwait(false);
+        await PersistAsync(cancellationToken).ConfigureAwait(false);
+    }
 
-    /// <summary>
-    /// Clears the conversation history.
-    /// </summary>
-    public void Reset()
-        => _conversationManager.Clear();
+    private async Task EnsureHistoryWithinLimitsAsync(CancellationToken cancellationToken)
+    {
+        if (_currentSession is null)
+        {
+            return;
+        }
 
-    /// <summary>
-    /// Replaces the conversation history with the supplied messages.
-    /// </summary>
-    /// <param name="messages">The messages that should become the active conversation.</param>
-    public void LoadHistory(IEnumerable<ChatMessage> messages)
-        => _conversationManager.Load(messages);
+        var messages = _conversationManager.Messages;
+        if (messages.Count == 0)
+        {
+            return;
+        }
+
+        var estimatedTokens = EstimateTokenCount(messages);
+        if (estimatedTokens <= ConversationTokenLimit)
+        {
+            _currentSession.Messages = messages.ToList();
+            return;
+        }
+
+        var preserveCount = Math.Min(PreserveTailMessageCount, messages.Count);
+        var toSummarize = messages.Take(messages.Count - preserveCount).ToList();
+        if (toSummarize.Count == 0)
+        {
+            _currentSession.Messages = messages.ToList();
+            return;
+        }
+
+        var summary = await SummarizeHistoryAsync(toSummarize, cancellationToken).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(summary))
+        {
+            _currentSession.Messages = messages.ToList();
+            return;
+        }
+
+        var compactHistory = new List<ChatMessage>
+        {
+            new()
+            {
+                Role = "system",
+                Content = $"Resumen del contexto: {summary}",
+            },
+        };
+        compactHistory.AddRange(messages.Skip(messages.Count - preserveCount));
+
+        _conversationManager.Load(compactHistory);
+        _currentSession.AgentState.LastSummary = summary;
+        AppendThoughtInternal($"Se generó un resumen automático que condensa {toSummarize.Count} mensajes previos.");
+        _currentSession.Messages = _conversationManager.Messages.ToList();
+    }
+
+    private async Task<string?> SummarizeHistoryAsync(IReadOnlyList<ChatMessage> messages, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var transcript = new StringBuilder();
+            foreach (var message in messages)
+            {
+                if (string.IsNullOrWhiteSpace(message.Content))
+                {
+                    continue;
+                }
+
+                transcript.AppendLine($"[{message.Role}] {message.Content}");
+            }
+
+            var prompt = new List<ChatMessage>
+            {
+                new()
+                {
+                    Role = "system",
+                    Content = "Eres un asistente que resume conversaciones técnicas para mantener el contexto relevante.",
+                },
+                new()
+                {
+                    Role = "user",
+                    Content = "Resume la siguiente conversación en español resaltando decisiones, archivos y acciones clave:\n\n" + transcript,
+                },
+            };
+
+            var config = _configurationService.Current;
+            var request = new ChatCompletionRequest
+            {
+                Model = !string.IsNullOrWhiteSpace(config.Agent.Model) ? config.Agent.Model! : config.Model,
+                Stream = false,
+                Temperature = 0.2,
+                TopP = 0.9,
+                MaxTokens = 512,
+                Messages = prompt,
+            };
+
+            var response = await _client.CreateChatCompletionAsync(request, cancellationToken).ConfigureAwait(false);
+            return response.Choices.FirstOrDefault()?.Message?.Content;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to summarize conversation history");
+            return null;
+        }
+    }
+
+    private void RefreshConfigurationSnapshot()
+    {
+        if (_currentSession is null)
+        {
+            return;
+        }
+
+        var config = _configurationService.Current;
+        var snapshot = _currentSession.AgentState.ConfigurationSnapshot;
+        snapshot.Clear();
+        snapshot["chat.model"] = config.Model;
+        snapshot["chat.temperature"] = config.Temperature.ToString("0.###", CultureInfo.InvariantCulture);
+        snapshot["chat.top_p"] = config.TopP.ToString("0.###", CultureInfo.InvariantCulture);
+        snapshot["chat.max_tokens"] = config.MaxTokens.ToString(CultureInfo.InvariantCulture);
+        snapshot["chat.frequency_penalty"] = config.FrequencyPenalty.ToString("0.###", CultureInfo.InvariantCulture);
+        snapshot["chat.presence_penalty"] = config.PresencePenalty.ToString("0.###", CultureInfo.InvariantCulture);
+        snapshot["chat.stream"] = config.Stream.ToString();
+        snapshot["agent.enabled"] = config.Agent.Enabled.ToString();
+        snapshot["agent.model"] = string.IsNullOrWhiteSpace(config.Agent.Model) ? "(heredado)" : config.Agent.Model!;
+        snapshot["agent.max_iterations"] = config.Agent.MaxIterations.ToString(CultureInfo.InvariantCulture);
+        snapshot["agent.allow_file_writes"] = config.Agent.AllowFileWrites.ToString();
+        snapshot["agent.working_directory"] = string.IsNullOrWhiteSpace(config.Agent.WorkingDirectory)
+            ? "."
+            : config.Agent.WorkingDirectory!;
+    }
+
+    private async Task PersistAsync(CancellationToken cancellationToken)
+    {
+        if (_currentSession is null)
+        {
+            return;
+        }
+
+        RefreshConfigurationSnapshot();
+        _currentSession.AgentState.LastUpdated = DateTimeOffset.UtcNow;
+        _currentSession.Messages = _conversationManager.Messages.ToList();
+        await _sessionStorage.SaveAsync(_currentSession, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static int EstimateTokenCount(IReadOnlyList<ChatMessage> messages)
+    {
+        var totalCharacters = messages.Sum(message => message.Content?.Length ?? 0);
+        return totalCharacters / EstimatedTokensPerCharacter;
+    }
+
+    private static IEnumerable<string> ExtractPaths(AgentToolInvocation invocation)
+    {
+        if (string.IsNullOrWhiteSpace(invocation.Arguments))
+        {
+            yield break;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(invocation.Arguments);
+            if (document.RootElement.ValueKind != JsonValueKind.Object)
+            {
+                yield break;
+            }
+
+            if (document.RootElement.TryGetProperty("path", out var pathElement) && pathElement.ValueKind == JsonValueKind.String)
+            {
+                yield return pathElement.GetString()!;
+            }
+
+            if (document.RootElement.TryGetProperty("target", out var targetElement) && targetElement.ValueKind == JsonValueKind.String)
+            {
+                yield return targetElement.GetString()!;
+            }
+        }
+        catch
+        {
+            yield break;
+        }
+    }
+
+    private void AppendThoughtInternal(string thought)
+    {
+        if (_currentSession is null)
+        {
+            return;
+        }
+
+        var log = _currentSession.AgentState.ThoughtLog;
+        log.Add(thought);
+        while (log.Count > ThoughtLogLimit)
+        {
+            log.RemoveAt(0);
+        }
+    }
+
+    private void NormalizeSession(ConversationSession session)
+    {
+        session.AgentState ??= new AgentState();
+        session.AgentState.ThoughtLog ??= new List<string>();
+        session.AgentState.ActiveTools ??= new List<string>();
+        session.AgentState.LoadedFiles ??= new List<string>();
+        session.AgentState.ConfigurationSnapshot ??= new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        session.ToolsUsed ??= new List<string>();
+        session.Messages ??= new List<ChatMessage>();
+    }
 
     private ChatCompletionRequest BuildRequest(bool? streamOverride)
     {

--- a/src/Application/Sessions/SessionStorageService.cs
+++ b/src/Application/Sessions/SessionStorageService.cs
@@ -1,5 +1,8 @@
-using System.Text.Json;
+using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
 using RapidCli.Domain.Models;
 
@@ -10,6 +13,13 @@ namespace RapidCli.Application.Sessions;
 /// </summary>
 public sealed class SessionStorageService
 {
+    private const string SessionsDirectoryName = "sessions";
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
     private readonly ILogger<SessionStorageService> _logger;
     private readonly string _sessionsDirectory;
 
@@ -20,59 +30,136 @@ public sealed class SessionStorageService
     public SessionStorageService(ILogger<SessionStorageService> logger)
     {
         _logger = logger;
-        _sessionsDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".rapidcli", "sessions");
+        _sessionsDirectory = Path.Combine(Directory.GetCurrentDirectory(), SessionsDirectoryName);
     }
 
     /// <summary>
-    /// Saves the provided messages under the given session name.
+    /// Creates a new session descriptor with the specified identifier.
     /// </summary>
-    /// <param name="sessionName">The identifier of the session.</param>
-    /// <param name="messages">The messages to persist.</param>
-    public async Task SaveAsync(string sessionName, IEnumerable<ChatMessage> messages)
+    /// <param name="sessionId">Optional identifier to associate with the session.</param>
+    public ConversationSession CreateSession(string? sessionId = null)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(sessionName);
+        Directory.CreateDirectory(_sessionsDirectory);
+
+        var id = !string.IsNullOrWhiteSpace(sessionId)
+            ? SanitizeSessionId(sessionId)
+            : GenerateSessionId();
+
+        var now = DateTimeOffset.UtcNow;
+        return new ConversationSession
+        {
+            Id = id,
+            CreatedAt = now,
+            UpdatedAt = now,
+            AgentState = new AgentState(),
+        };
+    }
+
+    /// <summary>
+    /// Persists the provided session to disk.
+    /// </summary>
+    /// <param name="session">The session to store.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public async Task SaveAsync(ConversationSession session, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentException.ThrowIfNullOrWhiteSpace(session.Id);
 
         try
         {
             Directory.CreateDirectory(_sessionsDirectory);
-            var path = GetSessionFile(sessionName);
-            var json = JsonSerializer.Serialize(messages, new JsonSerializerOptions
-            {
-                WriteIndented = true,
-            });
-            await File.WriteAllTextAsync(path, json).ConfigureAwait(false);
+            session.UpdatedAt = DateTimeOffset.UtcNow;
+            var json = JsonSerializer.Serialize(session, SerializerOptions);
+            var path = GetSessionFile(session.Id);
+            await File.WriteAllTextAsync(path, json, cancellationToken).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to save session {Session}", sessionName);
+            _logger.LogError(ex, "Failed to save session {Session}", session.Id);
             throw;
         }
     }
 
     /// <summary>
+    /// Creates a copy of the provided session using the specified identifier.
+    /// </summary>
+    /// <returns>The normalized identifier used to store the snapshot.</returns>
+    public async Task<string> SaveAsAsync(ConversationSession session, string newIdentifier, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentException.ThrowIfNullOrWhiteSpace(newIdentifier);
+
+        var sanitized = SanitizeSessionId(newIdentifier);
+        var clone = new ConversationSession
+        {
+            Id = sanitized,
+            CreatedAt = session.CreatedAt,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Messages = session.Messages.ToList(),
+            AgentState = session.AgentState ?? new AgentState(),
+            ToolsUsed = session.ToolsUsed.ToList(),
+        };
+
+        await SaveAsync(clone, cancellationToken).ConfigureAwait(false);
+        return sanitized;
+    }
+
+    /// <summary>
     /// Loads a previously saved session.
     /// </summary>
-    /// <param name="sessionName">The identifier of the session.</param>
-    /// <returns>The stored messages or an empty list if the session does not exist.</returns>
-    public async Task<IReadOnlyList<ChatMessage>> LoadAsync(string sessionName)
+    /// <param name="sessionId">The identifier of the session.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>The stored session or <c>null</c> if the session does not exist.</returns>
+    public async Task<ConversationSession?> LoadAsync(string sessionId, CancellationToken cancellationToken = default)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(sessionName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sessionId);
 
         try
         {
-            var path = GetSessionFile(sessionName);
+            var path = GetSessionFile(sessionId);
             if (!File.Exists(path))
             {
-                return Array.Empty<ChatMessage>();
+                return null;
             }
 
-            var json = await File.ReadAllTextAsync(path).ConfigureAwait(false);
-            var messages = JsonSerializer.Deserialize<IReadOnlyList<ChatMessage>>(json);
-            return messages ?? Array.Empty<ChatMessage>();
+            await using var stream = File.OpenRead(path);
+            var session = await JsonSerializer
+                .DeserializeAsync<ConversationSession>(stream, SerializerOptions, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (session is not null)
+            {
+                session.Id = SanitizeSessionId(session.Id);
+                session.AgentState ??= new AgentState();
+                session.ToolsUsed ??= new List<string>();
+                session.Messages ??= new List<ChatMessage>();
+                return session;
+            }
+
+            // Compatibility fallback with legacy format that stored only chat messages.
+            stream.Position = 0;
+            var legacyMessages = await JsonSerializer
+                .DeserializeAsync<IReadOnlyList<ChatMessage>>(stream, SerializerOptions, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (legacyMessages is null)
+            {
+                return null;
+            }
+
+            var info = new FileInfo(path);
+            return new ConversationSession
+            {
+                Id = SanitizeSessionId(sessionId),
+                CreatedAt = info.CreationTimeUtc,
+                UpdatedAt = info.LastWriteTimeUtc,
+                Messages = legacyMessages.ToList(),
+                AgentState = new AgentState(),
+            };
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to load session {Session}", sessionName);
+            _logger.LogError(ex, "Failed to load session {Session}", sessionId);
             throw;
         }
     }
@@ -80,20 +167,76 @@ public sealed class SessionStorageService
     /// <summary>
     /// Lists the names of the available saved sessions.
     /// </summary>
-    public IReadOnlyList<string> ListSessions()
+    public IReadOnlyList<ConversationSessionSummary> ListSessions()
     {
         if (!Directory.Exists(_sessionsDirectory))
         {
-            return Array.Empty<string>();
+            return Array.Empty<ConversationSessionSummary>();
         }
 
-        return Directory
-            .EnumerateFiles(_sessionsDirectory, "*.json")
-            .Select(file => Path.GetFileNameWithoutExtension(file))
-            .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
+        var summaries = new List<ConversationSessionSummary>();
+        foreach (var file in Directory.EnumerateFiles(_sessionsDirectory, "*.json"))
+        {
+            try
+            {
+                using var stream = File.OpenRead(file);
+                using var document = JsonDocument.Parse(stream);
+                var root = document.RootElement;
+
+                var id = root.TryGetProperty("id", out var idElement)
+                    ? SanitizeSessionId(idElement.GetString() ?? Path.GetFileNameWithoutExtension(file))
+                    : Path.GetFileNameWithoutExtension(file);
+
+                var createdAt = root.TryGetProperty("createdAt", out var createdElement)
+                    ? createdElement.GetDateTimeOffset()
+                    : File.GetCreationTimeUtc(file);
+
+                var updatedAt = root.TryGetProperty("updatedAt", out var updatedElement)
+                    ? updatedElement.GetDateTimeOffset()
+                    : File.GetLastWriteTimeUtc(file);
+
+                var messageCount = root.TryGetProperty("messages", out var messagesElement) && messagesElement.ValueKind == JsonValueKind.Array
+                    ? messagesElement.GetArrayLength()
+                    : 0;
+
+                var toolCount = root.TryGetProperty("toolsUsed", out var toolsElement) && toolsElement.ValueKind == JsonValueKind.Array
+                    ? toolsElement.GetArrayLength()
+                    : 0;
+
+                summaries.Add(new ConversationSessionSummary
+                {
+                    Id = id,
+                    CreatedAt = createdAt,
+                    UpdatedAt = updatedAt,
+                    MessageCount = messageCount,
+                    ToolCount = toolCount,
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to parse session metadata from {File}", file);
+            }
+        }
+
+        return summaries
+            .OrderByDescending(summary => summary.UpdatedAt)
+            .ThenBy(summary => summary.Id, StringComparer.OrdinalIgnoreCase)
             .ToList();
     }
 
-    private string GetSessionFile(string sessionName)
-        => Path.Combine(_sessionsDirectory, $"{sessionName}.json");
+    private string GetSessionFile(string sessionId)
+    {
+        var sanitized = SanitizeSessionId(sessionId);
+        return Path.Combine(_sessionsDirectory, $"{sanitized}.json");
+    }
+
+    private static string GenerateSessionId()
+        => $"session-{DateTimeOffset.UtcNow:yyyyMMddHHmmss}-{Guid.NewGuid():N[..6]}";
+
+    private static string SanitizeSessionId(string sessionId)
+    {
+        var invalidChars = Path.GetInvalidFileNameChars();
+        var cleaned = new string(sessionId.Where(ch => !invalidChars.Contains(ch)).ToArray());
+        return string.IsNullOrWhiteSpace(cleaned) ? GenerateSessionId() : cleaned;
+    }
 }

--- a/src/Domain/Models/AgentState.cs
+++ b/src/Domain/Models/AgentState.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace RapidCli.Domain.Models;
+
+/// <summary>
+/// Represents the internal state of the autonomous agent for a conversation session.
+/// </summary>
+public sealed class AgentState
+{
+    /// <summary>
+    /// Gets or sets the collection of file paths that have been read or written during the session.
+    /// </summary>
+    [JsonPropertyName("loadedFiles")]
+    public IList<string> LoadedFiles { get; set; } = new List<string>();
+
+    /// <summary>
+    /// Gets or sets the collection of tool identifiers used during the session.
+    /// </summary>
+    [JsonPropertyName("activeTools")]
+    public IList<string> ActiveTools { get; set; } = new List<string>();
+
+    /// <summary>
+    /// Gets or sets a dictionary with the configuration snapshot that was active for the agent.
+    /// </summary>
+    [JsonPropertyName("configurationSnapshot")]
+    public IDictionary<string, string> ConfigurationSnapshot { get; set; }
+        = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Gets or sets a collection capturing the internal reasoning traces shared with the user.
+    /// </summary>
+    [JsonPropertyName("thoughtLog")]
+    public IList<string> ThoughtLog { get; set; } = new List<string>();
+
+    /// <summary>
+    /// Gets or sets the most recent summary generated for the conversation history.
+    /// </summary>
+    [JsonPropertyName("lastSummary")]
+    public string? LastSummary { get; set; }
+        = null;
+
+    /// <summary>
+    /// Gets or sets the timestamp when the state was last updated.
+    /// </summary>
+    [JsonPropertyName("lastUpdated")]
+    public DateTimeOffset LastUpdated { get; set; } = DateTimeOffset.UtcNow;
+}

--- a/src/Domain/Models/ConversationSession.cs
+++ b/src/Domain/Models/ConversationSession.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace RapidCli.Domain.Models;
+
+/// <summary>
+/// Represents a persisted conversation session for the CLI assistant.
+/// </summary>
+public sealed class ConversationSession
+{
+    /// <summary>
+    /// Gets or sets the identifier associated with the session.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the timestamp when the session was created.
+    /// </summary>
+    [JsonPropertyName("createdAt")]
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    /// <summary>
+    /// Gets or sets the timestamp when the session was last updated.
+    /// </summary>
+    [JsonPropertyName("updatedAt")]
+    public DateTimeOffset UpdatedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    /// <summary>
+    /// Gets or sets the collection of messages exchanged during the session.
+    /// </summary>
+    [JsonPropertyName("messages")]
+    public IList<ChatMessage> Messages { get; set; } = new List<ChatMessage>();
+
+    /// <summary>
+    /// Gets or sets the agent state associated with the session.
+    /// </summary>
+    [JsonPropertyName("agentState")]
+    public AgentState AgentState { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the collection of tool identifiers used during the session.
+    /// </summary>
+    [JsonPropertyName("toolsUsed")]
+    public IList<string> ToolsUsed { get; set; } = new List<string>();
+}

--- a/src/Domain/Models/ConversationSessionSummary.cs
+++ b/src/Domain/Models/ConversationSessionSummary.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace RapidCli.Domain.Models;
+
+/// <summary>
+/// Represents a lightweight projection of a stored conversation session.
+/// </summary>
+public sealed class ConversationSessionSummary
+{
+    /// <summary>
+    /// Gets or sets the identifier of the session.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the timestamp when the session was created.
+    /// </summary>
+    [JsonPropertyName("createdAt")]
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    /// <summary>
+    /// Gets or sets the timestamp of the last update made to the session.
+    /// </summary>
+    [JsonPropertyName("updatedAt")]
+    public DateTimeOffset UpdatedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    /// <summary>
+    /// Gets or sets the number of messages stored in the session.
+    /// </summary>
+    [JsonPropertyName("messageCount")]
+    public int MessageCount { get; set; }
+        = 0;
+
+    /// <summary>
+    /// Gets or sets the number of tools registered as used within the session.
+    /// </summary>
+    [JsonPropertyName("toolCount")]
+    public int ToolCount { get; set; }
+        = 0;
+}


### PR DESCRIPTION
## Summary
- add dedicated session models for persistent chat history, agent state, and metadata listing
- extend the chat service to manage session lifecycle, token-aware summarisation, tool usage tracking, and reasoning logs
- update the CLI to auto-save sessions, expose session management commands, and surface agent "thinking" traces during execution

## Testing
- dotnet build *(fails: dotnet command not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6e1753d7c832387a306eaaa1a8386